### PR TITLE
Fix parser execution

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN bundle install --deployment --without rubocop
 VOLUME /errata
 COPY default_config.json /etc/errata_parser.json
 CMD bundle exec errata_parser.rb \
-      --config /etc/errata_parser.json \
+      --config /errata/config.json \
       --debian /errata/ \
       --ubuntu /errata/ \
       --metadata

--- a/default_config.json
+++ b/default_config.json
@@ -51,6 +51,9 @@
     },
     "whitelists": {
       "releases": [
+        "focal",
+        "bionic",
+        "xenial",
         "focal-security",
         "bionic-security",
         "xenial-security"

--- a/errata_parser.rb
+++ b/errata_parser.rb
@@ -122,7 +122,7 @@ rescue StandardError => e
   fatal("Error loading config: #{e}", 3)
 end
 
-if $PROGRAM_NAME == __FILE__
+if File.basename($PROGRAM_NAME) == File.basename(__FILE__)
   # parse command-line parameters
   options = parse_commandline
 


### PR DESCRIPTION
- fix whitelist in derfault_config for Ubuntu
- container should use config from volume
- fix execution in certain cases (e.g. utilizing shebang)